### PR TITLE
fix: 채팅방 나가기 시 db에서 삭제되도록 수정

### DIFF
--- a/src/main/java/com/team9/anicare/domain/chat/controller/AdminChatRoomController.java
+++ b/src/main/java/com/team9/anicare/domain/chat/controller/AdminChatRoomController.java
@@ -76,7 +76,7 @@ public class AdminChatRoomController {
      * 관리자 - 채팅방 퇴장
      */
     @Operation(summary = "채팅방 퇴장 (Admin)", description = "관리자가 채팅방에서 나갑니다.")
-    @PostMapping("/rooms/{roomId}/exit")
+    @DeleteMapping("/rooms/{roomId}/exit")
     public ResponseEntity<String> exitChatRoomAsAdmin(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable String roomId) {

--- a/src/main/java/com/team9/anicare/domain/chat/controller/UserChatRoomController.java
+++ b/src/main/java/com/team9/anicare/domain/chat/controller/UserChatRoomController.java
@@ -77,7 +77,7 @@ public class UserChatRoomController {
 
 
     @Operation(summary = "채팅방 퇴장 (User)", description = "사용자가 채팅방에서 나갑니다.")
-    @PostMapping("/rooms/{roomId}/exit")
+    @DeleteMapping("/rooms/{roomId}/exit")
     public ResponseEntity<String> exitChatRoom(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable String roomId) {


### PR DESCRIPTION
## 📄 Description
- 채팅방 나가기 시 db에서 삭제되도록 수정했습니다.

## 🔨 Changes
- 관리자가 나가면 활성 상태만 점검 (대기중인지 관리자가 배정된건지)
- 사용자가 나가면 다른 조건 검사할 필요 없이 chat room, chat message, chat participant db 모두 삭제

